### PR TITLE
Add new price_round and time_format features

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ octoblock:
   import_code: AGILE-FLEX-22-11-25
   export_code: AGILE-OUTGOING-19-05-13
   use_timezone: False
+  price_round: 2
+  time_format: "%Y-%m-%dT%H:%M:%S%Z"
   blocks:
     - hour: 1
       import: True
@@ -100,6 +102,10 @@ Install, configure and start the integration, go to Developer Tools/States and f
 NB: If you get the tariff code wrong (e.g. forget to remove the E-1R- prefix or -H suffix) you will get an error `ERROR octoblock: Error 404 getting incoming tariff data: {"detail":"Not found."}` reported in the appdaemon log and the rest of the octoblock configuration (custom blocks etc) will be ignored!
 
 `use_timezone` can be set to True or False, and defaults to False, it allows you to specify if the date/time should be displayed in UTC (False), or using Europe/London (True) as the timezone. For example, `2020-03-29T02:00:00Z` or `2020-03-29T03:00:00 BST` respectively.
+
+`price_round` can be set to the number of decimal places to round the average price for the specified period to, and defaults to 4 if not specified.  For example, set to 2 to round to 2 decimal places, e.g. 14.56 p/kWh.
+
+`time_format` can be set to a [strftime format code](https://www.geeksforgeeks.org/python-strftime-function/) that the date/time that the block starts at. If not specified it defaults to `%Y-%m-%dT%H:%M:%S%Z`, e.g. `2020-03-19T20:00:00Z`.  An easier to read and shorter time format for example could be `%a %-I:%M %p` which would display the block start time as `Tue 1:30 AM`.  Note that if you change the time_format from the default then you may need to adjust any automation scripts so that they can still match the returned block time.  If you are only displaying the block time in a Lovelace UI dashboard display as shown below then this won't be an issue.
 
 ### Blocks
 
@@ -158,7 +164,7 @@ show_header_toggle: false
 entities:
   - entity: sensor.octopus_1hour_price
     icon: 'mdi:flash'
-    name: Price (p/kWh)
+    name: Price
   - entity: sensor.octopus_1hour_time
     icon: 'mdi:clock-outline'
     name: Time
@@ -169,7 +175,7 @@ show_header_toggle: false
 entities:
   - entity: sensor.octopus_1_5hour_price
     icon: 'mdi:flash'
-    name: Price (p/kWh)
+    name: Price
   - entity: sensor.octopus_1_5hour_time
     icon: 'mdi:clock-outline'
     name: Time

--- a/apps/octoblock/octoblock.py
+++ b/apps/octoblock/octoblock.py
@@ -324,7 +324,7 @@ class OctoBlock(hass.Hass):
                     else:
                         date_time = dateutil.parser.parse(self.time)
                         self.time = date_time.strftime(self.time_format)
-                    
+
                     self.log(
                         "Best priced {} hour ".format(str(self.hours))
                         + "period starts at: {}".format(self.time),

--- a/apps/octoblock/octoblock.py
+++ b/apps/octoblock/octoblock.py
@@ -15,6 +15,8 @@ class OctoBlock(hass.Hass):
         self.import_code = self.args.get("import_code", "AGILE-FLEX-22-11-25")
         self.export_code = self.args.get("export_code", "AGILE-OUTGOING-19-05-13")
         self.use_timezone = self.args.get("use_timezone", False)
+        self.price_round = self.args.get("price_round", 4)
+        self.time_format = self.args.get("time_format", "%Y-%m-%dT%H:%M:%S%Z")
         self.blocks = self.args.get("blocks", None)
         self.lookaheads = self.args.get("lookaheads", None)
 
@@ -68,7 +70,7 @@ class OctoBlock(hass.Hass):
                 self.duration_ahead = lookahead.get("duration_ahead", 12)
                 self.name = lookahead.get("name", None)
                 self.log(
-                    "Lookahead:\nPrice: {}".format(self.price)
+                    "Lookahead:\nPrice: {}".format(round(self.price, int(self.price_round)))
                     + "\nFor: {}".format(self.duration_ahead)
                     + "\nName: {}".format(self.name),
                     level="DEBUG",
@@ -241,7 +243,7 @@ class OctoBlock(hass.Hass):
             i += 1
         self.price = tariffresults[i]["value_inc_vat"]
         self.log(
-            f"{now_or_next} {direction} price is: {self.price} p/kWh", level="INFO"
+            f"{now_or_next} {direction} price is: {round(self.price, int(self.price_round))} p/kWh", level="INFO"
         )
         self.log(
             f"**Tariff Date get_period_and_cost: {tariffresults[i]['valid_from']} **",
@@ -293,7 +295,7 @@ class OctoBlock(hass.Hass):
                 self.log(
                     "Lowest average price for "
                     + "{}".format(str(self.hours))
-                    + " hour block is: {} p/kWh".format(self.price),
+                    + " hour block is: {} p/kWh".format(round(self.price, int(self.price_round))),
                     level="INFO",
                 )
             elif self.outgoing:
@@ -304,7 +306,7 @@ class OctoBlock(hass.Hass):
                 self.log(
                     "Highest average price for "
                     + "{}".format(str(self.hours))
-                    + " hour block is: {} p/kWh".format(self.price),
+                    + " hour block is: {} p/kWh".format(round(self.price, int(self.price_round))),
                     level="INFO",
                 )
 
@@ -315,11 +317,14 @@ class OctoBlock(hass.Hass):
                     self.log("**Time: {}**".format(self.time), level="DEBUG")
 
                     if self.use_timezone:
-                        fmt = "%Y-%m-%dT%H:%M:%S %Z"
                         greenwich = pytz.timezone("Europe/London")
                         date_time = dateutil.parser.parse(self.time)
                         local_datetime = date_time.astimezone(greenwich)
-                        self.time = local_datetime.strftime(fmt)
+                        self.time = local_datetime.strftime(self.time_format)
+                    else:
+                        date_time = dateutil.parser.parse(self.time)
+                        self.time = date_time.strftime(self.time_format)
+                    
                     self.log(
                         "Best priced {} hour ".format(str(self.hours))
                         + "period starts at: {}".format(self.time),
@@ -338,13 +343,13 @@ class OctoBlock(hass.Hass):
             if self.hours == 0:
                 self.set_state(
                     "sensor.octopus_current_price",
-                    state=round(self.price, 4),
+                    state=round(self.price, int(self.price_round)),
                     attributes={"unit_of_measurement": "p/kWh", "icon": "mdi:flash"},
                 )
             elif str(self.hours).lower() == "next":
                 self.set_state(
                     "sensor.octopus_next_price",
-                    state=round(self.price, 4),
+                    state=round(self.price, int(self.price_round)),
                     attributes={"unit_of_measurement": "p/kWh", "icon": "mdi:flash"},
                 )
             else:
@@ -359,14 +364,14 @@ class OctoBlock(hass.Hass):
                 )
                 self.set_state(
                     entity_id_p,
-                    state=round(self.price, 4),
+                    state=round(self.price, int(self.price_round)),
                     attributes={"unit_of_measurement": "p/kWh", "icon": "mdi:flash"},
                 )
         elif self.outgoing:
             if self.hours == 0:
                 self.set_state(
                     "sensor.octopus_export_current_price",
-                    state=round(self.price, 4),
+                    state=round(self.price, int(self.price_round)),
                     attributes={
                         "unit_of_measurement": "p/kWh",
                         "icon": "mdi:flash-outline",
@@ -375,7 +380,7 @@ class OctoBlock(hass.Hass):
             elif str(self.hours).lower() == "next":
                 self.set_state(
                     "sensor.octopus_export_next_price",
-                    state=round(self.price, 4),
+                    state=round(self.price, int(self.price_round)),
                     attributes={
                         "unit_of_measurement": "p/kWh",
                         "icon": "mdi:flash-outline",
@@ -393,7 +398,7 @@ class OctoBlock(hass.Hass):
                 )
                 self.set_state(
                     entity_id_p,
-                    state=round(self.price, 4),
+                    state=round(self.price, int(self.price_round)),
                     attributes={
                         "unit_of_measurement": "p/kWh",
                         "icon": "mdi:flash-outline",
@@ -427,7 +432,7 @@ class OctoBlock(hass.Hass):
             name = str(self.name).replace(".", "_")
             self.entity_id = "sensor." + name
         else:
-            price = str(self.price).replace(".", "_")
+            price = str(round(self.price, int(self.price_round))).replace(".", "_")
             duration_ahead = str(self.duration_ahead).replace(".", "_")
             self.entity_id = (
                 "sensor.lookahead_for_cost_"


### PR DESCRIPTION
Added two new optional configuration features to apps.yaml, price_round to specify the number of decimal places to round the average price for the block to, and time_format to specify the format that the date/time of the block is returned as.
Both of these are primarily for improving the readability of the octoblock output when displaying the octoblock "best xx hour Price" entities on a Lovelace dashboard